### PR TITLE
Support for 3D Biomes (1.16-1.17 nether)

### DIFF
--- a/spigot_1_16_R2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R2/NMSBiomeUtils.java
+++ b/spigot_1_16_R2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R2/NMSBiomeUtils.java
@@ -53,10 +53,10 @@ class NMSBiomeUtils {
     }
 
     BiomeBase getBiomeBase(final Location location) {
-        final BlockPosition pos = new BlockPosition(location.getBlockX(), 0, location.getBlockZ());
+        final BlockPosition pos = new BlockPosition(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final Chunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAtWorldCoords(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getBiomeIndex().getBiome(pos.getX(), 0, pos.getZ());
+            return nmsChunk.getBiomeIndex().getBiome(pos.getX(), pos.getY(), pos.getZ());
         }
         return null;
     }

--- a/spigot_1_16_R3/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R3/NMSBiomeUtils.java
+++ b/spigot_1_16_R3/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R3/NMSBiomeUtils.java
@@ -53,10 +53,10 @@ class NMSBiomeUtils {
     }
 
     BiomeBase getBiomeBase(final Location location) {
-        final BlockPosition pos = new BlockPosition(location.getBlockX(), 0, location.getBlockZ());
+        final BlockPosition pos = new BlockPosition(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final Chunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAtWorldCoords(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getBiomeIndex().getBiome(pos.getX(), 0, pos.getZ());
+            return nmsChunk.getBiomeIndex().getBiome(pos.getX(), pos.getY(), pos.getZ());
         }
         return null;
     }

--- a/spigot_1_17_R1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_17_R1/NMSBiomeUtils.java
+++ b/spigot_1_17_R1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_17_R1/NMSBiomeUtils.java
@@ -53,10 +53,10 @@ class NMSBiomeUtils {
     }
 
     Biome getBiomeBase(final Location location) {
-        final BlockPos pos = new BlockPos(location.getBlockX(), 0, location.getBlockZ());
+        final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getBiomes().getNoiseBiome(pos.getX(), 0, pos.getZ());
+            return nmsChunk.getBiomes().getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
         }
         return null;
     }


### PR DESCRIPTION
NMSBiomeUtils of every version below 1.18 is using 0 as Y location.
3D biomes in the nether has been a thing since 1.16, so every version of NMSBiomeUtils in JeffLib must get Y pos for the players.